### PR TITLE
Add detailed placement and setup steps

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Copy this file to .env and fill in your OpenAI API key.
+OPENAI_API_KEY=sk-your-api-key

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.pyc
+.env
+.DS_Store
+minutes*.md

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,20 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Run meeting_notes",
+      "type": "python",
+      "request": "launch",
+      "program": "${workspaceFolder}/meeting_notes.py",
+      "console": "integratedTerminal",
+      "envFile": "${workspaceFolder}/.env",
+      "args": [
+        "path/to/audio.m4a",
+        "--output",
+        "minutes.md",
+        "--title",
+        "팀 미팅"
+      ]
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,144 @@
-# gomsik811
+# Automatic Meeting Minutes from Audio
+
+This repo contains a small Python CLI that converts a recorded meeting audio file into a clean set of meeting minutes using OpenAI Whisper for transcription and GPT-based models for summarization.
+
+## Quick start (한 줄 요약)
+1. **필수 설치**: `pip install -r requirements.txt`
+2. **키 위치**: 프로젝트 루트에 `.env` 만들고 `OPENAI_API_KEY=...` 한 줄 저장
+3. **실행**: `python meeting_notes.py input_audio.m4a --output minutes.md --title "팀 미팅"`
+4. **길이 긴 파일**: `--chunk-seconds 300` 같이 초 단위로 잘라 Whisper 부담 줄이기
+
+## 무엇을 어디에 두면 되는지 (폴더/파일 위치)
+- **프로젝트 루트**: `meeting_notes.py`, `requirements.txt`, `README.md`와 같은 위치.
+- **.env**: 루트에 `.env` 파일을 만들고 아래처럼 API 키를 한 줄로 적어둡니다.
+  ```env
+  OPENAI_API_KEY=sk-...
+  ```
+- **오디오 파일**: 아무 위치나 가능하지만, 경로가 길면 `audio/input.m4a` 같이 프로젝트 내부 폴더를 만들어 넣어두면 편합니다.
+- **출력 파일**: 기본은 루트에 `minutes.md`로 저장되며 `--output logs/2024-06-미팅.md`처럼 원하는 위치를 지정할 수 있습니다.
+
+## 단계별 자세한 사용법
+### 0) 사전 준비 (필수 설치)
+- Python 3.11+ (Anaconda 환경 권장)
+- `pip install -r requirements.txt`
+
+### 1) Anaconda Prompt에서 환경 만들기/켜기
+```bash
+conda create -n meeting-minutes python=3.11 -y
+conda activate meeting-minutes
+```
+- `argument -n/--name expected one argument` 에러가 나면 `meeting-minutes` 이름 부분이 빠지지 않았는지 확인하고 위 두 줄을 한 줄씩 그대로 복사해 실행하세요.
+
+### 2) API 키 저장 위치 정하기
+- **가장 쉬운 방법**: 루트에 `.env` 파일 생성 → `OPENAI_API_KEY=...` 입력 → 저장.
+- **터미널에서만 쓰기**: Anaconda Prompt에서 `setx OPENAI_API_KEY "sk-..."` 실행 후 새 창을 엽니다.
+
+### 3) 오디오 파일 두기
+- 파일 위치는 자유입니다. 예시로 프로젝트 루트에 `audio/weekly.m4a`를 넣었다고 가정합니다.
+
+### 4) VS Code에서 실행 (GUI 선호 시)
+1. VS Code 실행 → 명령 팔레트(⇧⌘P / Ctrl+Shift+P) → **Python: Select Interpreter** → `meeting-minutes` 선택
+2. 좌측 **Run & Debug** → **Run meeting_notes** 구성 선택
+3. `.vscode/launch.json`의 `programArgs` 값을 오디오 경로로 수정 (예: `audio/weekly.m4a`)
+4. 디버그 실행 ▶️ → 완료 후 루트에 `minutes.md` 생성
+
+### 5) 터미널에서 바로 실행 (빠른 방법)
+```bash
+python meeting_notes.py audio/weekly.m4a --output minutes.md --title "주간 회의"
+```
+
+### 6) 길이가 긴 녹음 처리
+- 5분 단위로 자르려면 `--chunk-seconds 300` 옵션을 추가합니다.
+  ```bash
+  python meeting_notes.py audio/weekly.m4a --chunk-seconds 300 --output minutes.md
+  ```
+- 더 짧게 자르고 싶으면 숫자(초 단위)만 줄이면 됩니다.
+
+### 7) 결과물을 GitHub/유튜브에 쓰기
+- 생성된 `minutes.md`에는 요약/결정/액션아이템/타임라인/전체 녹취가 포함됩니다.
+- README나 이슈 설명, 유튜브 영상 설명란에 그대로 붙여넣으면 됩니다.
+
+## 가장 빠르게 쓰는 순서 (요약)
+1. **가상환경 열기**: Anaconda Prompt에서 `conda activate meeting-minutes`(없다면 README 아래 가이드를 따라 생성).
+2. **키 확인**: 프로젝트 루트에 `.env`를 두고 `OPENAI_API_KEY=...`가 들어있는지 확인.
+3. **파일만 넣어 실행**: VS Code 디버그 구성(**Run meeting_notes**)에서 `programArgs`를 녹음 파일 경로로 바꾸고 실행하거나, 터미널에서 아래처럼 실행합니다.
+   ```bash
+   python meeting_notes.py path/to/audio.m4a --output minutes.md --title "팀 미팅"
+   ```
+4. **길이 긴 파일**: 필요하면 `--chunk-seconds 300` 옵션을 추가해 5분 단위로 자릅니다.
+
+## Features
+- Loads `OPENAI_API_KEY` automatically from the environment or `.env`.
+- Validates audio input and supports chunking long files for stable Whisper runs.
+- Produces structured minutes including summary, decisions, action items, and timestamps.
+- Exports minutes as Markdown for easy sharing to GitHub and video descriptions on YouTube.
+
+## Example output
+```markdown
+# Meeting Minutes - 2024-06-11
+
+## Summary
+- Team aligned on launch timeline for Q3.
+- Backend migration blocked by missing staging data.
+
+## Decisions
+- Proceed with feature freeze on June 20.
+
+## Action Items
+- [ ] Alice — deliver staging dump by Jun 13
+- [ ] Bob — finalize QA checklist by Jun 18
+
+## Timeline
+- 00:00:00 Kickoff & agenda
+- 00:05:12 Backend migration discussion
+- 00:22:41 QA readiness review
+```
+
+## CLI options
+- `--title` / `--date`: customize the Markdown heading and date stamp.
+- `--chunk-seconds`: split long audio into N-second segments before transcription.
+- `--language`: language hint for Whisper (e.g., `en`, `ko`).
+- `--whisper-prompt`: context phrase that can improve transcription accuracy for names/jargon.
+- `--summary-model`: GPT model for summarization (`gpt-4o-mini` by default).
+
+## Notes
+- Whisper works best with clear audio; consider recording directly from your meeting tool.
+- For very long recordings, adjust `--chunk-seconds` to balance speed and quality.
+- If you plan to publish a walkthrough on YouTube, use the generated Markdown minutes as your video description.
+
+## 아나콘다 프롬프트 + VS Code 환경 세팅
+Windows에서 Anaconda Prompt와 VS Code를 함께 쓰는 경우 아래 순서를 따르면 바로 실행할 수 있습니다.
+
+1. **가상환경 생성 및 활성화** (Python 3.11 이상 권장)
+   ```bash
+   conda create -n meeting-minutes python=3.11 -y
+   conda activate meeting-minutes
+   ```
+   - `argument -n/--name expected one argument` 에러가 뜨면, 위 명령어에서 `meeting-minutes` 부분이 빠지지 않았는지 확인하고 한 줄씩 그대로 복사해 실행하세요.
+
+2. **필수 라이브러리 설치**
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+3. **API 키 설정 (.env 권장)**
+   - 프로젝트 루트에 `.env` 파일을 만들고 아래처럼 키를 넣습니다.
+     ```env
+     OPENAI_API_KEY=sk-...
+     ```
+   - Anaconda Prompt에서만 쓸 거라면 환경 변수로도 설정할 수 있습니다.
+
+4. **VS Code에서 인터프리터 선택**
+   - VS Code 명령 팔레트(⇧⌘P / Ctrl+Shift+P) → "Python: Select Interpreter" → `meeting-minutes` 선택.
+
+5. **디버그 실행**
+   - `.vscode/launch.json` 기본 설정이 포함되어 있습니다.
+   - VS Code 좌측 Run & Debug에서 **"Run meeting_notes"** 선택 후 녹음 파일 경로(`programArgs`)만 바꿔 실행하면 `minutes.md`가 생성됩니다.
+
+6. **터미널 수동 실행 (선호 시)**
+   ```bash
+   python meeting_notes.py path/to/audio.m4a --output minutes.md --title "팀 미팅"
+   ```
+
+> 팁: 길이가 긴 녹음은 `--chunk-seconds 300`처럼 5분 단위로 자르면 Whisper 메모리 사용량이 줄고 VS Code 터미널에서도 안정적으로 돌아갑니다.
+

--- a/meeting_notes.py
+++ b/meeting_notes.py
@@ -1,0 +1,223 @@
+"""CLI to turn meeting audio recordings into structured minutes.
+
+Requires an `OPENAI_API_KEY` environment variable.
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import pathlib
+from dataclasses import dataclass
+from tempfile import NamedTemporaryFile
+from typing import Iterable, List, Optional
+
+from openai import OpenAI
+from pydub import AudioSegment
+from dotenv import load_dotenv
+
+
+@dataclass
+class ActionItem:
+    description: str
+    owner: Optional[str] = None
+    due_date: Optional[str] = None
+
+
+@dataclass
+class MeetingMinutes:
+    date: str
+    summary: List[str]
+    decisions: List[str]
+    action_items: List[ActionItem]
+    timeline: List[str]
+    transcript: str
+
+    def to_markdown(self, title: str) -> str:
+        lines: List[str] = [f"# {title} - {self.date}", ""]
+        if self.summary:
+            lines.append("## Summary")
+            lines.extend([f"- {item}" for item in self.summary])
+            lines.append("")
+        if self.decisions:
+            lines.append("## Decisions")
+            lines.extend([f"- {item}" for item in self.decisions])
+            lines.append("")
+        if self.action_items:
+            lines.append("## Action Items")
+            for action in self.action_items:
+                owner_text = f"{action.owner} — " if action.owner else ""
+                due_text = f" (due {action.due_date})" if action.due_date else ""
+                lines.append(f"- [ ] {owner_text}{action.description}{due_text}")
+            lines.append("")
+        if self.timeline:
+            lines.append("## Timeline")
+            lines.extend([f"- {item}" for item in self.timeline])
+            lines.append("")
+        lines.append("## Full Transcript")
+        lines.append(self.transcript)
+        return "\n".join(lines).strip() + "\n"
+
+
+SYSTEM_PROMPT = """You are a meticulous meeting scribe. Generate concise, structured minutes from a transcript.
+Return only JSON using the following schema:
+{
+  "summary": ["bullet", ...],
+  "decisions": ["decision", ...],
+  "action_items": [
+     {"description": "", "owner": "", "due_date": ""}
+  ],
+  "timeline": ["HH:MM:SS topic" , ...]
+}
+Keep bullets crisp and actionable. If data is missing, use empty arrays.
+"""
+
+
+def require_api_key() -> str:
+    """Load and return the OpenAI API key, exiting early if missing."""
+
+    load_dotenv()
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise SystemExit("Missing OPENAI_API_KEY environment variable.")
+    return api_key
+
+
+def validate_audio_path(audio_path: pathlib.Path) -> pathlib.Path:
+    if not audio_path.exists():
+        raise SystemExit(f"Audio file not found: {audio_path}")
+    if not audio_path.is_file():
+        raise SystemExit(f"Audio path is not a file: {audio_path}")
+    return audio_path
+
+
+def chunk_audio(audio_path: pathlib.Path, chunk_seconds: int) -> Iterable[AudioSegment]:
+    audio = AudioSegment.from_file(audio_path)
+    stride = chunk_seconds * 1000
+    for start_ms in range(0, len(audio), stride):
+        yield audio[start_ms : start_ms + stride]
+
+
+def transcribe_audio(client: OpenAI, audio_path: pathlib.Path, prompt: Optional[str], chunk_seconds: Optional[int], language: Optional[str]) -> str:
+    audio_path = validate_audio_path(audio_path)
+
+    if chunk_seconds and chunk_seconds > 0:
+        segments = []
+        for segment in chunk_audio(audio_path, chunk_seconds):
+            with NamedTemporaryFile(suffix=".mp3") as temp:
+                segment.export(temp.name, format="mp3")
+                response = client.audio.transcriptions.create(
+                    model="whisper-1",
+                    file=open(temp.name, "rb"),
+                    prompt=prompt,
+                    language=language,
+                )
+            segments.append(response.text)
+        return "\n".join(segments)
+
+    with open(audio_path, "rb") as audio_file:
+        response = client.audio.transcriptions.create(
+            model="whisper-1",
+            file=audio_file,
+            prompt=prompt,
+            language=language,
+        )
+    return response.text
+
+
+def summarize_transcript(client: OpenAI, transcript: str, model: str, meeting_title: str, meeting_date: str) -> MeetingMinutes:
+    messages = [
+        {"role": "system", "content": SYSTEM_PROMPT},
+        {
+            "role": "user",
+            "content": (
+                f"Meeting: {meeting_title}\n"
+                f"Date: {meeting_date}\n"
+                "Transcript:\n" + transcript
+            ),
+        },
+    ]
+    completion = client.chat.completions.create(
+        model=model,
+        messages=messages,
+        temperature=0.3,
+    )
+    content = completion.choices[0].message.content or "{}"
+
+    data = {}
+    for candidate in (content, content.strip().strip("`")):
+        try:
+            data = json.loads(candidate)
+            break
+        except json.JSONDecodeError:
+            continue
+
+    summary = data.get("summary", []) if isinstance(data.get("summary"), list) else []
+    decisions = data.get("decisions", []) if isinstance(data.get("decisions"), list) else []
+    raw_actions = data.get("action_items", []) if isinstance(data.get("action_items"), list) else []
+    action_items = [
+        ActionItem(
+            description=item.get("description", "").strip(),
+            owner=item.get("owner") or None,
+            due_date=item.get("due_date") or None,
+        )
+        for item in raw_actions
+        if isinstance(item, dict) and item.get("description")
+    ]
+    timeline = data.get("timeline", []) if isinstance(data.get("timeline"), list) else []
+
+    return MeetingMinutes(
+        date=meeting_date,
+        summary=summary,
+        decisions=decisions,
+        action_items=action_items,
+        timeline=timeline,
+        transcript=transcript,
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Convert meeting audio into structured minutes.")
+    parser.add_argument("audio", type=pathlib.Path, help="Path to the audio file (mp3, m4a, wav, etc.)")
+    parser.add_argument("--output", type=pathlib.Path, default=pathlib.Path("minutes.md"), help="Where to write the minutes (Markdown).")
+    parser.add_argument("--title", type=str, default="Meeting Minutes", help="Title used in the Markdown output.")
+    parser.add_argument("--date", type=str, default=dt.date.today().isoformat(), help="Date string to stamp the minutes.")
+    parser.add_argument("--chunk-seconds", type=int, default=None, help="Chunk size for long audio (in seconds).")
+    parser.add_argument("--language", type=str, default=None, help="Language hint for Whisper (e.g., en, ko).")
+    parser.add_argument("--whisper-prompt", type=str, default=None, help="Optional prompt to bias Whisper transcription.")
+    parser.add_argument(
+        "--summary-model",
+        type=str,
+        default="gpt-4o-mini",
+        help="Model used for summarization (e.g., gpt-4o-mini, gpt-4o).",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    client = OpenAI(api_key=require_api_key())
+
+    transcript = transcribe_audio(
+        client=client,
+        audio_path=args.audio,
+        prompt=args.whisper_prompt,
+        chunk_seconds=args.chunk_seconds,
+        language=args.language,
+    )
+
+    minutes = summarize_transcript(
+        client=client,
+        transcript=transcript,
+        model=args.summary_model,
+        meeting_title=args.title,
+        meeting_date=args.date,
+    )
+
+    args.output.write_text(minutes.to_markdown(args.title), encoding="utf-8")
+    print(f"Minutes saved to {args.output.resolve()}")
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+openai>=1.31.0
+pydub>=0.25.1
+python-dotenv>=1.0.1


### PR DESCRIPTION
## Summary
- expand README with file placement guidance for .env, audio input, and output locations
- add step-by-step Anaconda, VS Code, and terminal run instructions with chunking examples

## Testing
- python -m compileall meeting_notes.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d1bf252c08320b7d1c01e7a800f4b)